### PR TITLE
Patch Tree to allow expansion if custom renderer

### DIFF
--- a/.yarn/versions/bbf5c5bd.yml
+++ b/.yarn/versions/bbf5c5bd.yml
@@ -1,0 +1,3 @@
+releases:
+  "@essex/components": patch
+  essex-toolkit-stories: patch

--- a/packages/components/src/Tree/Tree.stories.tsx
+++ b/packages/components/src/Tree/Tree.stories.tsx
@@ -679,7 +679,7 @@ export const CustomRenderers = {
 							{defaultRenderer?.(props)}
 						</div>
 					)
-				}
+				},
 			},
 		],
 	},

--- a/packages/components/src/Tree/Tree.stories.tsx
+++ b/packages/components/src/Tree/Tree.stories.tsx
@@ -653,6 +653,34 @@ export const CustomRenderers = {
 					},
 				],
 			},
+			{
+				key: 'item-4',
+				text: 'Item 4 (no children, but custom renderer)',
+				onRenderContent: (props: any, defaultRenderer: any) => {
+					const depth = (props?.item.depth || 0) + 1
+					return (
+						<div>
+							<div
+								style={{
+									display: 'flex',
+									flexDirection: 'column',
+									gap: 4,
+									padding: 4,
+									paddingLeft: depth * 12 + 32,
+								}}
+							>
+								<div style={fieldStyle}>
+									<div>Add codebook</div>
+								</div>
+								<div style={fieldStyle}>
+									<div>Add workflow</div>
+								</div>
+							</div>
+							{defaultRenderer?.(props)}
+						</div>
+					)
+				}
+			},
 		],
 	},
 }

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -75,7 +75,9 @@ export const TreeItem: React.FC<TreeItemProps> = memo(function TreeItem(props) {
 					<div style={_styles.indicator} />
 					<div style={_styles.flexContainer}>
 						<Indicator {...props} styles={_styles} />
-						{(item.children || item.onRenderContent) && !narrow && <IconButton {..._expandButtonProps} />}
+						{(item.children || item.onRenderContent) && !narrow && (
+							<IconButton {..._expandButtonProps} />
+						)}
 						<div className="title">{renderTitle(props)}</div>
 						{item.menuItems && <IconButton {..._menuButtonProps} />}
 					</div>

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -75,7 +75,7 @@ export const TreeItem: React.FC<TreeItemProps> = memo(function TreeItem(props) {
 					<div style={_styles.indicator} />
 					<div style={_styles.flexContainer}>
 						<Indicator {...props} styles={_styles} />
-						{item.children && !narrow && <IconButton {..._expandButtonProps} />}
+						{(item.children || item.onRenderContent) && !narrow && <IconButton {..._expandButtonProps} />}
 						<div className="title">{renderTitle(props)}</div>
 						{item.menuItems && <IconButton {..._menuButtonProps} />}
 					</div>


### PR DESCRIPTION
Quick fix: previously, a tree item would only render the expand/collapse button if it had children. However, if there is a custom content renderer we want to allow expansion as well, even if there are not child tree items.