### PR TITLE
Allow for reference-able node-configuration

### DIFF
--- a/python/reactivedataflow/pyproject.toml
+++ b/python/reactivedataflow/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reactivedataflow"
-version = "0.1.3"
+version = "0.1.4"
 description = "Reactive Dataflow Graphs"
 license = "MIT"
 authors = ["Chris Trevino <chtrevin@microsoft.com>"]

--- a/python/reactivedataflow/pyproject.toml
+++ b/python/reactivedataflow/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reactivedataflow"
-version = "0.1.2"
+version = "0.1.3"
 description = "Reactive Dataflow Graphs"
 license = "MIT"
 authors = ["Chris Trevino <chtrevin@microsoft.com>"]

--- a/python/reactivedataflow/reactivedataflow/graph_builder.py
+++ b/python/reactivedataflow/reactivedataflow/graph_builder.py
@@ -21,7 +21,7 @@ from .errors import (
     RequiredNodeInputNotFoundError,
 )
 from .execution_graph import ExecutionGraph
-from .model import Graph, Output
+from .model import Graph, Output, ValRef
 from .nodes import ExecutionNode, InputNode, Node
 from .registry import Registry
 
@@ -166,6 +166,14 @@ class GraphBuilder:
 
                 registration = registry.get(node["verb"])
                 node_config = node.get("config", {}) or {}
+                for key, value in node_config.items():
+                    if isinstance(value, ValRef):
+                        if value.reference:
+                            node_config[key] = config[value.reference]
+                        else:
+                            node_config[key] = value.value
+                    else:
+                        node_config[key] = value
 
                 # Set up an execution node
                 verb = registry.get_verb_function(node["verb"])

--- a/python/reactivedataflow/reactivedataflow/model.py
+++ b/python/reactivedataflow/reactivedataflow/model.py
@@ -14,12 +14,22 @@ class InputNode(BaseModel):
     id: str = Field(..., description="Node identifier.")
 
 
+class ValRef(BaseModel):
+    """A model containing either a value or a reference to a global configuration."""
+
+    value: Any | None = Field(default=None, description="The value.")
+    reference: str | None = Field(
+        default=None, description="The name of the global configuration to reference."
+    )
+    type: str | None = Field(default=None, description="The type of the value.")
+
+
 class Node(BaseModel):
     """Processing Node Model."""
 
     id: str = Field(..., description="Node identifier.")
     verb: str = Field(..., description="The verb name to use.")
-    config: dict[str, Any] = Field(
+    config: dict[str, str | int | float | bool | ValRef] = Field(
         default_factory=dict, description="Configuration parameters."
     )
 


### PR DESCRIPTION
Node configuration must now either be a primitive value (bool, int, str), or a `ValRef` container, which may contain a literal value or a reference to a global configuration name.