### PR TITLE
Improved Async Support

### DIFF
--- a/python/reactivedataflow/poetry.lock
+++ b/python/reactivedataflow/poetry.lock
@@ -391,6 +391,24 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.23.7"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_asyncio-0.23.7-py3-none-any.whl", hash = "sha256:009b48127fbe44518a547bddd25611551b0e43ccdbf1e67d12479f569832c20b"},
+    {file = "pytest_asyncio-0.23.7.tar.gz", hash = "sha256:5f5c72948f4c49e7db4f29f2521d4031f1c27f86e57b046126654083d4770268"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0,<9"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "reactivex"
 version = "4.0.4"
 description = "ReactiveX (Rx) for Python"
@@ -455,4 +473,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "3fcdc939beade41f875e687225fcd3a843110e3a896436b479852913cdef9a66"
+content-hash = "15de0a5a096b26ac67be988839719979f74621d848e7d3526ae4d918972fbef4"

--- a/python/reactivedataflow/pyproject.toml
+++ b/python/reactivedataflow/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reactivedataflow"
-version = "0.1.4"
+version = "0.1.5"
 description = "Reactive Dataflow Graphs"
 license = "MIT"
 authors = ["Chris Trevino <chtrevin@microsoft.com>"]

--- a/python/reactivedataflow/pyproject.toml
+++ b/python/reactivedataflow/pyproject.toml
@@ -20,6 +20,7 @@ pytest = "^8.2.2"
 pyright = "^1.1.366"
 coverage = "^7.5.3"
 numpy = "<2"
+pytest-asyncio = "^0.23.7"
 
 [build-system]
 requires = ["poetry-core"]
@@ -137,3 +138,4 @@ log_cli = true
 log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_mode = "auto"

--- a/python/reactivedataflow/reactivedataflow/__init__.py
+++ b/python/reactivedataflow/reactivedataflow/__init__.py
@@ -7,7 +7,6 @@ from .decorators import (
     connect_output,
     emit_conditions,
     fire_conditions,
-    handle_async_output,
     verb,
 )
 from .execution_graph import ExecutionGraph
@@ -65,6 +64,5 @@ __all__ = [
     "connect_output",
     "emit_conditions",
     "fire_conditions",
-    "handle_async_output",
     "verb",
 ]

--- a/python/reactivedataflow/reactivedataflow/decorators/__init__.py
+++ b/python/reactivedataflow/reactivedataflow/decorators/__init__.py
@@ -6,7 +6,6 @@ from .connect_input import connect_input
 from .connect_output import connect_output
 from .emit_conditions import emit_conditions
 from .fire_conditions import fire_conditions
-from .handle_async_output import handle_async_output
 from .verb import verb
 
 __all__ = [
@@ -17,6 +16,5 @@ __all__ = [
     "connect_output",
     "emit_conditions",
     "fire_conditions",
-    "handle_async_output",
     "verb",
 ]

--- a/python/reactivedataflow/reactivedataflow/decorators/handle_async_output.py
+++ b/python/reactivedataflow/reactivedataflow/decorators/handle_async_output.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 Microsoft Corporation.
 """reactivedataflow Outputs Decorator."""
 
-import asyncio
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
+from inspect import iscoroutine
 from typing import Any, ParamSpec, TypeVar
 
 from reactivedataflow.nodes import (
@@ -13,17 +13,21 @@ P = ParamSpec("P")
 T = TypeVar("T")
 
 
-def handle_async_output() -> Callable[[Callable[P, Any]], Callable[P, VerbOutput]]:
+def handle_async_output() -> (
+    Callable[[Callable[P, Any]], Callable[P, Awaitable[VerbOutput]]]
+):
     """Unroll async output.
 
     Args:
         default_output (bool): The default output of the function.
     """
 
-    def wrap_fn(fn: Callable[P, Any]) -> Callable[P, VerbOutput]:
-        def wrapped_fn(*args: P.args, **kwargs: P.kwargs) -> VerbOutput:
+    def wrap_fn(fn: Callable[P, Any]) -> Callable[P, Awaitable[VerbOutput]]:
+        async def wrapped_fn(*args: P.args, **kwargs: P.kwargs) -> VerbOutput:
             result = fn(*args, **kwargs)
-            return asyncio.run(result)
+            if iscoroutine(result):
+                return await result
+            return result
 
         wrapped_fn.__qualname__ = f"{fn.__qualname__}_wrapasync"
         return wrapped_fn

--- a/python/reactivedataflow/reactivedataflow/nodes/__init__.py
+++ b/python/reactivedataflow/reactivedataflow/nodes/__init__.py
@@ -3,11 +3,18 @@
 
 from .execution_node import ExecutionNode
 from .input_node import InputNode
-from .io import EmitMode, InputMode, OutputMode, VerbInput, VerbOutput
+from .io import (
+    EmitMode,
+    InputMode,
+    OutputMode,
+    VerbInput,
+    VerbOutput,
+)
 from .node import Node
-from .types import EmitCondition, FireCondition, VerbFunction
+from .types import AsyncVerbFunction, EmitCondition, FireCondition, VerbFunction
 
 __all__ = [
+    "AsyncVerbFunction",
     "EmitCondition",
     "EmitMode",
     "ExecutionNode",

--- a/python/reactivedataflow/reactivedataflow/nodes/input_node.py
+++ b/python/reactivedataflow/reactivedataflow/nodes/input_node.py
@@ -29,14 +29,17 @@ class InputNode(Node):
         self._values = rx.subject.BehaviorSubject(None)
         self._subscription = None
 
-    def dispose(self) -> None:
+    def detach(self) -> None:
         """Detach the node from all inputs."""
         if self._subscription:
             self._subscription.dispose()
 
+    async def drain(self) -> None:
+        """Wait for the node to finish processing."""
+
     def attach(self, value: rx.Observable[Any]) -> None:
         """Set the value of a given output."""
-        self.dispose()
+        self.detach()
         self._subscription = value.subscribe(lambda v: self._values.on_next(v))
 
     def output(self, name: str = default_output) -> rx.Observable[Any]:

--- a/python/reactivedataflow/reactivedataflow/nodes/node.py
+++ b/python/reactivedataflow/reactivedataflow/nodes/node.py
@@ -16,8 +16,12 @@ class Node(Protocol):
         """Get the ID of the node."""
         ...
 
-    def dispose(self) -> None:
+    def detach(self) -> None:
         """Detach the node from all inputs."""
+        ...
+
+    async def drain(self) -> None:
+        """Wait for the node to finish processing."""
         ...
 
     def output(self, name: str = default_output) -> rx.Observable[Any]:

--- a/python/reactivedataflow/reactivedataflow/nodes/types.py
+++ b/python/reactivedataflow/reactivedataflow/nodes/types.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2024 Microsoft Corporation.
 """Shared reactivedataflow Types."""
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 from .io import VerbInput, VerbOutput
 
 VerbFunction = Callable[[VerbInput], VerbOutput]
+AsyncVerbFunction = Callable[[VerbInput], Awaitable[VerbOutput]]
 FireCondition = Callable[[VerbInput], bool]
 EmitCondition = Callable[[VerbInput, VerbOutput], bool]

--- a/python/reactivedataflow/reactivedataflow/types.py
+++ b/python/reactivedataflow/reactivedataflow/types.py
@@ -2,13 +2,14 @@
 """reactivedataflow Types."""
 
 from .decorators import AnyFn, Decorator
-from .nodes import EmitCondition, FireCondition, VerbFunction
+from .nodes import AsyncVerbFunction, EmitCondition, FireCondition, VerbFunction
 from .ports import PortBinding
 from .registry import VerbConstructor
 from .utils.equality import IsEqualCheck
 
 __all__ = [
     "AnyFn",
+    "AsyncVerbFunction",
     "Decorator",
     "EmitCondition",
     "FireCondition",

--- a/python/reactivedataflow/tests/unit/decorators/test_connect_output.py
+++ b/python/reactivedataflow/tests/unit/decorators/test_connect_output.py
@@ -1,15 +1,12 @@
 # Copyright (c) 2024 Microsoft Corporation.
 """Output decorator tests."""
 
-import asyncio
-
 import pytest
 
 from reactivedataflow import (
     OutputMode,
     VerbOutput,
     connect_output,
-    handle_async_output,
 )
 from reactivedataflow.constants import default_output
 from reactivedataflow.errors import (
@@ -74,14 +71,3 @@ def test_raw_mode_output():
     result = stub()
     assert result.outputs == {default_output: 123}
     assert not result.no_output
-
-
-def test_async_output():
-    @connect_output(mode=OutputMode.Value)
-    @handle_async_output()
-    async def stub():
-        await asyncio.sleep(0.001)
-        return 1
-
-    result = stub()
-    assert result.outputs == {default_output: 1}

--- a/python/reactivedataflow/tests/unit/decorators/test_verb.py
+++ b/python/reactivedataflow/tests/unit/decorators/test_verb.py
@@ -2,6 +2,7 @@
 """reactivedataflow Verb Tests."""
 
 import asyncio
+from typing import cast
 
 import pytest
 
@@ -15,6 +16,7 @@ from reactivedataflow import (
 )
 from reactivedataflow.constants import default_output
 from reactivedataflow.errors import VerbNotFoundError
+from reactivedataflow.types import AsyncVerbFunction
 
 
 def test_verb_registration():
@@ -42,7 +44,7 @@ def test_raw_verb():
     assert result.outputs[default_output] == 3
 
 
-def test_async_verb():
+async def test_async_verb():
     registry = Registry()
 
     @verb(name="test_fn", registry=registry, output_mode=OutputMode.Raw, is_async=True)
@@ -51,11 +53,11 @@ def test_async_verb():
         await asyncio.sleep(0.001)
         return VerbOutput(outputs={default_output: result})
 
-    decorated_fn = registry.get_verb_function("test_fn")
+    decorated_fn = cast(AsyncVerbFunction, registry.get_verb_function("test_fn"))
 
-    result = decorated_fn(VerbInput(named_inputs={}))
+    result = await decorated_fn(VerbInput(named_inputs={}))
     assert result.outputs[default_output] == 200
-    result = decorated_fn(VerbInput(named_inputs={"a": 1, "b": 2}))
+    result = await decorated_fn(VerbInput(named_inputs={"a": 1, "b": 2}))
     assert result.outputs[default_output] == 3
 
 

--- a/python/reactivedataflow/tests/unit/nodes/test_execution_node.py
+++ b/python/reactivedataflow/tests/unit/nodes/test_execution_node.py
@@ -22,7 +22,7 @@ from reactivedataflow.ports import (
 from reactivedataflow.registry import Registry
 
 
-def test_configure_and_reconfigure():
+async def test_configure_and_reconfigure():
     registry = Registry()
 
     @verb(
@@ -36,15 +36,17 @@ def test_configure_and_reconfigure():
 
     wrapped_fn = registry.get_verb_function("execute")
     node = ExecutionNode("a", wrapped_fn, config={"value": "Hello"})
+    await node.drain()
     assert node.config.get("value") == "Hello"
     assert node.output_value() == "Hello"
 
     node.config = {"value": "World"}
+    await node.drain()
     assert node.config.get("value") == "World"
     assert node.output_value() == "World"
 
 
-def test_execution_node_with_raw_input():
+async def test_execution_node_with_raw_input():
     registry = Registry()
 
     @verb(
@@ -72,10 +74,11 @@ def test_execution_node_with_raw_input():
         "input_1": rx.of("Hello"),
         "input_2": rx.of("World"),
     })
+    await node.drain()
     assert output == "Hello World"
 
 
-def test_execution_node_with_named_inputs():
+async def test_execution_node_with_named_inputs():
     registry = Registry()
 
     @verb(
@@ -90,6 +93,7 @@ def test_execution_node_with_named_inputs():
 
     output: str | None = None
     node = ExecutionNode("a", wrapped_fn)
+    await node.drain()
 
     def on_output(o: str):
         nonlocal output
@@ -101,10 +105,11 @@ def test_execution_node_with_named_inputs():
         "input_1": rx.of("Hello"),
         "input_2": rx.of("World"),
     })
+    await node.drain()
     assert output == "Hello World"
 
 
-def test_execution_node_with_named_required_inputs():
+async def test_execution_node_with_named_required_inputs():
     registry = Registry()
 
     @verb(
@@ -130,10 +135,11 @@ def test_execution_node_with_named_required_inputs():
         "input_1": rx.of("Hello"),
         "input_2": rx.of("World"),
     })
+    await node.drain()
     assert output == "Hello World"
 
 
-def test_execution_node_with_required_inputs():
+async def test_execution_node_with_required_inputs():
     registry = Registry()
 
     @verb(
@@ -162,10 +168,11 @@ def test_execution_node_with_required_inputs():
         "input_1": rx.of("Hello"),
         "input_2": rx.of("World"),
     })
+    await node.drain()
     assert output == "Hello World"
 
 
-def test_execution_node_with_required_config():
+async def test_execution_node_with_required_config():
     registry = Registry()
 
     @verb(
@@ -194,10 +201,11 @@ def test_execution_node_with_required_config():
         "conf_1": "Hello",
         "conf_2": "World",
     }
+    await node.drain()
     assert output == "Hello World"
 
 
-def test_execution_node_with_required_config_and_inputs():
+async def test_execution_node_with_required_config_and_inputs():
     registry = Registry()
 
     @verb(
@@ -231,14 +239,16 @@ def test_execution_node_with_required_config_and_inputs():
         "conf_1": "Hello",
         "conf_2": "World",
     }
+    await node.drain()
     assert output is None
     node.attach({
         "input_1": rx.of("Hi"),
     })
+    await node.drain()
     assert output == "Hi Hello World"
 
 
-def test_execution_node_with_optional_inputs():
+async def test_execution_node_with_optional_inputs():
     registry = Registry()
 
     @verb(
@@ -265,12 +275,14 @@ def test_execution_node_with_optional_inputs():
 
     node.output().subscribe(on_output)
     node.attach({"input_1": rx.of("Hello")})
+    await node.drain()
     assert output == "Hello "
     node.attach({"input_1": rx.of("Hello"), "input_2": rx.of("World")})
+    await node.drain()
     assert output == "Hello World"
 
 
-def test_execution_node_with_multiple_outputs():
+async def test_execution_node_with_multiple_outputs():
     registry = Registry()
 
     @verb(
@@ -310,11 +322,12 @@ def test_execution_node_with_multiple_outputs():
         "input_1": rx.of("Hello"),
         "input_2": rx.of("World"),
     })
+    await node.drain()
     assert output_1 == "Hello World"
     assert output_2 == "World Hello"
 
 
-def test_execution_node_with_array_inputs():
+async def test_execution_node_with_array_inputs():
     registry = Registry()
 
     @verb(
@@ -337,6 +350,8 @@ def test_execution_node_with_array_inputs():
 
     node.output().subscribe(on_output)
     node.attach(array_inputs=[rx.just(1), rx.just(2)])
+    await node.drain()
     assert output == 3
     node.attach(array_inputs=[rx.just(2), rx.just(4), rx.of(5, 6)])
+    await node.drain()
     assert output == 12

--- a/python/reactivedataflow/tests/unit/nodes/test_input_node.py
+++ b/python/reactivedataflow/tests/unit/nodes/test_input_node.py
@@ -9,7 +9,7 @@ from reactivedataflow.nodes import InputNode
 def test_input_node_has_id():
     node = InputNode("a")
     assert node.id == "a"
-    node.dispose()
+    node.detach()
 
 
 def test_input_node_attach():
@@ -23,4 +23,4 @@ def test_input_node_attach():
 
     first_attach.on_next(3)
     assert node.output_value() == 2
-    node.dispose()
+    node.detach()


### PR DESCRIPTION
The existing `handle_async` directive used `asyncio.run`, which precluded using an outer event loop. Instead of unrolling async into sync, this PR handles async functions by detecting first if they are awaitable, and then by introducing synchronization methods on `Node` and `Graph` interfaces to drain the event queue.