### PR TITLE
Use shallow-copies of node-inputs on recompute

### DIFF
--- a/python/reactivedataflow/pyproject.toml
+++ b/python/reactivedataflow/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reactivedataflow"
-version = "0.1.7"
+version = "0.1.8"
 description = "Reactive Dataflow Graphs"
 license = "MIT"
 authors = ["Chris Trevino <chtrevin@microsoft.com>"]

--- a/python/reactivedataflow/reactivedataflow/conditions.py
+++ b/python/reactivedataflow/reactivedataflow/conditions.py
@@ -5,6 +5,7 @@ from typing import Any, TypeVar, cast
 
 from reactivedataflow.nodes import EmitCondition, FireCondition, VerbInput, VerbOutput
 
+from .constants import default_output
 from .utils.equality import IsEqualCheck, default_is_equal
 
 
@@ -59,6 +60,29 @@ def array_input_values_are_defined() -> FireCondition:
 
 
 T = TypeVar("T")
+
+
+def array_result_non_empty(name: str = default_output) -> EmitCondition:
+    """Create an emit condition to emit when the given array output is non-empty."""
+
+    def check_array_results_non_empty(_inputs: VerbInput, outputs: VerbOutput) -> bool:
+        return (
+            name in outputs.outputs
+            and outputs.outputs[name]
+            and isinstance(outputs.outputs[name], list)
+            and len(outputs.outputs[name]) > 0
+        )
+
+    return check_array_results_non_empty
+
+
+def output_is_not_none(name: str) -> EmitCondition:
+    """Create an emit condition to emit when the given output is not None."""
+
+    def check_output_is_not_none(_inputs: VerbInput, outputs: VerbOutput) -> bool:
+        return name in outputs.outputs and outputs.outputs[name] is not None
+
+    return check_output_is_not_none
 
 
 def output_changed(

--- a/python/reactivedataflow/reactivedataflow/graph_builder.py
+++ b/python/reactivedataflow/reactivedataflow/graph_builder.py
@@ -303,4 +303,6 @@ class GraphBuilder:
 
         validate_node_requirements()
 
-        return ExecutionGraph(nodes, self._outputs)
+        visit_order = list(nx.topological_sort(self._graph))
+
+        return ExecutionGraph(nodes, self._outputs, visit_order)


### PR DESCRIPTION
This PR uses shallow-copies for the recompute step. This prevents multiple, rapid recomputes from using the same data. This PR also introduces a couple of new output-emitting conditions, and updates the `graph.drain()` method to use a topological visit order so that any late updates are fully propagated through the graph.