### PR TITLE
Add input data to fnllm cache

### DIFF
--- a/python/fnllm/fnllm/services/cache_interactor.py
+++ b/python/fnllm/fnllm/services/cache_interactor.py
@@ -41,7 +41,7 @@ class CacheInteractor:
             await self._events.on_cache_hit(key, name)
         else:
             entry = await func()
-            await self._cache.set(key, entry.model_dump())
+            await self._cache.set(key, entry.model_dump(), {"input": key_data})
             await self._events.on_cache_miss(key, name)
 
         return entry

--- a/python/fnllm/pyproject.toml
+++ b/python/fnllm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fnllm"
-version = "0.0.2"
+version = "0.0.3"
 description = "A function-based LLM protocol and wrapper."
 authors = [
     "Chris Trevino <chtrevin@microsoft.com>",


### PR DESCRIPTION
Current cache entries don't contain input data in the file contents. Having the input data in cache entries is a way for developers to verify that the inputs to a response are correct.