### PR TITLE
Parse env vars after loading config from sources

### DIFF
--- a/python/essex-config/.vscode/settings.json
+++ b/python/essex-config/.vscode/settings.json
@@ -6,5 +6,10 @@
 			"source.fixAll": "explicit"
 		},
 		"editor.defaultFormatter": "charliermarsh.ruff"
-	}
+    },
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/python/essex-config/essex_config/config.py
+++ b/python/essex-config/essex_config/config.py
@@ -1,9 +1,11 @@
 """Main configuration module for the essex_config package."""
 
 import inspect
+import os
 from functools import cache
 from types import UnionType
 from typing import (
+    Any,
     TypeVar,
     Union,
     cast,
@@ -22,6 +24,7 @@ from essex_config.field_annotations import (
     get_annotation,
 )
 from essex_config.sources import EnvSource, Source
+from essex_config.utils import parse_string_template
 
 DEFAULT_SOURCE_LIST: list[Source] = [EnvSource()]
 
@@ -36,6 +39,7 @@ def load_config(
     prefix: str = "",
     inner: bool = False,
     refresh_config: bool = False,
+    parse_env_values: bool = False,
 ) -> T:
     """Instantiate the configuration and all values.
 
@@ -59,7 +63,7 @@ def load_config(
     """
     if refresh_config:
         _load_config.cache_clear()
-    return _load_config(cls, tuple(sources), prefix, inner)
+    return _load_config(cls, tuple(sources), prefix, inner, parse_env_values)
 
 
 @cache
@@ -68,6 +72,7 @@ def _load_config(
     sources: tuple[Source, ...],
     prefix: str = "",
     inner: bool = False,
+    parse_env_values: bool = False,
 ) -> T:
     """Instantiate the configuration and all values.
 
@@ -119,7 +124,11 @@ def _load_config(
                         field_prefix += f".{name}" if field_prefix != "" else name
                     try:
                         values[name] = _load_config(
-                            type_, sources, prefix=field_prefix, inner=True
+                            type_,
+                            sources,
+                            prefix=field_prefix,
+                            inner=True,
+                            parse_env_values=parse_env_values,
                         )
                     except Exception:  # noqa: S112, BLE001
                         continue
@@ -131,9 +140,19 @@ def _load_config(
             if prefix_annotation is None:
                 field_prefix += f".{name}" if field_prefix != "" else name
             values[name] = _load_config(
-                field_type, sources, prefix=field_prefix, inner=True
+                field_type,
+                sources,
+                prefix=field_prefix,
+                inner=True,
+                parse_env_values=parse_env_values,
             )
             continue
+
+        env_values: dict[str, Any] = {}
+        for source in sources:
+            if isinstance(source, EnvSource):
+                extra_data = source.get_data()
+                env_values = {**extra_data, **env_values}
 
         value = None
         for source in sources:
@@ -183,6 +202,9 @@ def _load_config(
             value = info.default
         if value is None and info.default_factory is not None:
             value = info.default_factory()
+
+        if parse_env_values:
+            value = parse_string_template(value, {**os.environ, **env_values})
 
         if (value is None or value is PydanticUndefined) and info.is_required():
             msg = f"Value for {name} is required and not found in any source."

--- a/python/essex-config/essex_config/config.py
+++ b/python/essex-config/essex_config/config.py
@@ -149,10 +149,9 @@ def _load_config(
             continue
 
         env_values: dict[str, Any] = {}
-        for source in sources:
-            if isinstance(source, EnvSource):
-                extra_data = source.get_data()
-                env_values = {**extra_data, **env_values}
+        for source in filter(lambda src: isinstance(src, EnvSource), sources):
+            source = cast(EnvSource, source)
+            env_values = {**source.get_data(), **env_values}
 
         value = None
         for source in sources:

--- a/python/essex-config/essex_config/sources/env_source.py
+++ b/python/essex-config/essex_config/sources/env_source.py
@@ -47,6 +47,12 @@ class EnvSource(Source):
             raise FileNotFoundError(msg)
         return {}
 
+    def get_data(self) -> dict[str, Any]:
+        """Get the data from the environment."""
+        if not self._file_path:
+            return {}
+        return EnvSource.__get_data(self._file_path, self._use_env_var, self._required)
+
     def _get_value(
         self,
         key: str,

--- a/python/essex-config/essex_config/utils.py
+++ b/python/essex-config/essex_config/utils.py
@@ -6,13 +6,12 @@ from typing import Any
 
 def parse_string_template(value: Any, data: dict[str, Any]) -> Any:
     """Parse the string templates in str, list[str], and dict[, str]."""
-    value_type: type = type(value)
-    match value_type.__name__:
-        case "str":
+    match value:
+        case str():
             return Template(value).substitute(data)
-        case "list":
+        case list():
             return [parse_string_template(item, data) for item in value]
-        case "dict":
+        case dict():
             return {key: parse_string_template(val, data) for key, val in value.items()}
         case _:
             return value

--- a/python/essex-config/essex_config/utils.py
+++ b/python/essex-config/essex_config/utils.py
@@ -1,0 +1,16 @@
+"""Utility functions for the essex_config package."""
+
+from string import Template
+from typing import Any
+
+
+def parse_string_template(value: Any, data: dict[str, Any]) -> Any:
+    """Parse the string templates in str, list[str], and dict[, str]."""
+    if isinstance(value, str):
+        return Template(value).substitute(data)
+    if isinstance(value, list):
+        return [parse_string_template(item, data) for item in value]
+    if isinstance(value, dict):
+        return {key: parse_string_template(val, data) for key, val in value.items()}
+
+    return value

--- a/python/essex-config/essex_config/utils.py
+++ b/python/essex-config/essex_config/utils.py
@@ -6,11 +6,13 @@ from typing import Any
 
 def parse_string_template(value: Any, data: dict[str, Any]) -> Any:
     """Parse the string templates in str, list[str], and dict[, str]."""
-    if isinstance(value, str):
-        return Template(value).substitute(data)
-    if isinstance(value, list):
-        return [parse_string_template(item, data) for item in value]
-    if isinstance(value, dict):
-        return {key: parse_string_template(val, data) for key, val in value.items()}
-
-    return value
+    value_type: type = type(value)
+    match value_type.__name__:
+        case "str":
+            return Template(value).substitute(data)
+        case "list":
+            return [parse_string_template(item, data) for item in value]
+        case "dict":
+            return {key: parse_string_template(val, data) for key, val in value.items()}
+        case _:
+            return value

--- a/python/essex-config/pyproject.toml
+++ b/python/essex-config/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Andres Morales <andresmor@microsoft.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.11"
 pydantic = "^2.7.3"
 azure-identity = "^1.16.0"
 azure-keyvault-secrets = "^4.8.0"

--- a/python/essex-config/pyproject.toml
+++ b/python/essex-config/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Andres Morales <andresmor@microsoft.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.10"
 pydantic = "^2.7.3"
 azure-identity = "^1.16.0"
 azure-keyvault-secrets = "^4.8.0"

--- a/python/essex-config/tests/unit/test_config.py
+++ b/python/essex-config/tests/unit/test_config.py
@@ -1,7 +1,10 @@
 """Test configuration for the essex-config package."""
 
+import os
 import re
+from pathlib import Path
 from typing import Annotated, Any, TypeVar
+from unittest import mock
 
 import pytest
 from pydantic import BaseModel, Field
@@ -14,6 +17,16 @@ from essex_config.sources.env_source import EnvSource
 from essex_config.sources.utils import json_list_parser, plain_text_list_parser
 
 T = TypeVar("T")
+
+
+@pytest.fixture()
+def _mock_env_vars():
+    with mock.patch.dict(
+        os.environ,
+        {"TEST_VALUE": "test value"},
+        clear=True,
+    ):
+        yield
 
 
 class MockSource(Source):
@@ -35,6 +48,11 @@ class MockSource(Source):
             "hex_string": "0xDEADBEEF",
             "lower_false": "false",
             "plain_text_list": "1,2,3,4",
+            "env_var": "${TEST_VALUE}",
+            "env_list": '["${TEST_VALUE}", "world"]',
+            "env_dict": '{"key": "${TEST_VALUE}", "key2": "world"}',
+            "escaped_template_str": "$${DO_NOT_REPLACE}",
+            "nested.env_var": "${TEST_VALUE}",
         }
         super().__init__(prefix)
 
@@ -419,3 +437,61 @@ def test_default_order_behavior():
     )
 
     assert basic_config.value == {"a": 1}
+
+
+@pytest.mark.usefixtures("_mock_env_vars")
+def test_parsing_env_variables():
+    class NestedConfig(BaseModel):
+        env_var: str
+
+    class BasicConfiguration(BaseModel):
+        env_var: str
+        escaped_template_str: str
+        nested: NestedConfig
+        env_list: Annotated[list[str], Parser(json_list_parser)]
+        env_dict: dict[str, str]
+
+    basic_config = load_config(
+        BasicConfiguration, sources=[MockSource()], parse_env_values=True
+    )
+    assert basic_config.env_var == "test value"
+    assert basic_config.escaped_template_str == "${DO_NOT_REPLACE}"
+    assert basic_config.nested.env_var == "test value"
+    assert basic_config.env_list == ["test value", "world"]
+    assert basic_config.env_dict == {"key": "test value", "key2": "world"}
+
+    assert type(basic_config) == BasicConfiguration
+
+
+def test_parsing_missing_env_variables():
+    class BasicConfiguration(BaseModel):
+        env_var: str
+
+    with pytest.raises(
+        KeyError,
+        match=re.escape("TEST_VALUE"),
+    ):
+        load_config(
+            BasicConfiguration,
+            sources=[MockSource()],
+            parse_env_values=True,
+        )
+
+
+def test_parsing_env_variables_with_dotenv_file():
+    class BasicConfiguration(BaseModel):
+        env_var: str
+        escaped_template_str: str
+
+    env_file = (Path(__file__).parent / ".." / ".env.test").resolve()
+
+    basic_config = load_config(
+        BasicConfiguration,
+        sources=[MockSource(), EnvSource(file_path=env_file, required=True)],
+        parse_env_values=True,
+        refresh_config=True,
+    )
+    assert basic_config.env_var == "test value"
+    assert basic_config.escaped_template_str == "${DO_NOT_REPLACE}"
+
+    assert type(basic_config) == BasicConfiguration

--- a/python/essex-config/tests/unit/test_config.py
+++ b/python/essex-config/tests/unit/test_config.py
@@ -450,6 +450,7 @@ def test_parsing_env_variables():
         nested: NestedConfig
         env_list: Annotated[list[str], Parser(json_list_parser)]
         env_dict: dict[str, str]
+        other: set[str] = Field(default_factory=lambda: {"hello"})
 
     basic_config = load_config(
         BasicConfiguration, sources=[MockSource()], parse_env_values=True
@@ -459,6 +460,7 @@ def test_parsing_env_variables():
     assert basic_config.nested.env_var == "test value"
     assert basic_config.env_list == ["test value", "world"]
     assert basic_config.env_dict == {"key": "test value", "key2": "world"}
+    assert basic_config.other == {"hello"}
 
     assert type(basic_config) == BasicConfiguration
 
@@ -487,7 +489,11 @@ def test_parsing_env_variables_with_dotenv_file():
 
     basic_config = load_config(
         BasicConfiguration,
-        sources=[MockSource(), EnvSource(file_path=env_file, required=True)],
+        sources=[
+            MockSource(),
+            EnvSource(file_path=env_file, required=True),
+            EnvSource(),
+        ],
         parse_env_values=True,
         refresh_config=True,
     )


### PR DESCRIPTION
- Parse environment variables into config after
      loading values from all sources.
- Uses string Template syntax of ${SOME_VAR} to
    reference environment variables.
- Support $${} syntax for escaping ${} in string
    templates. Allows for the $${timestamp} use case
    so users may perform their own string parsing
    after config loading.
- load dotenv files from env sources, preferring
    values defined in earlier files over later ones
    and preferring values defined in dotenv files
    over os.environ.