### PR TITLE
Handle poisoned cache entries and common errors

### DIFF
--- a/python/fnllm/fnllm/caching/blob.py
+++ b/python/fnllm/fnllm/caching/blob.py
@@ -133,9 +133,15 @@ class BlobCache(Cache):
         except ResourceNotFoundError:
             return None
         else:
-            blob_data = blob_data.decode(self._encoding)
-            data = json.loads(blob_data)
-            return data["result"]
+            try:
+                blob_data = blob_data.decode(self._encoding)
+                data = json.loads(blob_data)
+            except json.JSONDecodeError:
+                return None
+            except UnicodeDecodeError:
+                return None
+            else:
+                return data["result"]
 
     async def set(
         self, key: str, value: Any, metadata: dict[str, Any] | None = None

--- a/python/fnllm/fnllm/caching/file.py
+++ b/python/fnllm/fnllm/caching/file.py
@@ -48,9 +48,6 @@ class FileCache(Cache):
         except json.JSONDecodeError:
             _log.warning("Cache entry %s is corrupted", path)
             return None
-        except FileNotFoundError:
-            _log.error("File %s not found", path)
-            return None
         except PermissionError:
             _log.error("Permission denied for file %s", path)
             return None

--- a/python/fnllm/fnllm/caching/file.py
+++ b/python/fnllm/fnllm/caching/file.py
@@ -43,8 +43,20 @@ class FileCache(Cache):
         if not path.exists():
             return None
 
-        # throw if result is None
-        cache_entry = json.loads(path.read_text(encoding=self._encoding))
+        try:
+            cache_entry = json.loads(path.read_text(encoding=self._encoding))
+        except json.JSONDecodeError:
+            _log.warning("Cache entry %s is corrupted", path)
+            return None
+        except FileNotFoundError:
+            _log.error("File %s not found", path)
+            return None
+        except PermissionError:
+            _log.error("Permission denied for file %s", path)
+            return None
+        except UnicodeDecodeError:
+            _log.error("Encoding error reading file %s", path)
+            return None
 
         # Mark the cache entry as updated to keep it alive
         cache_entry["accessed"] = time.time()

--- a/python/fnllm/tests/unit/caching/test_blob.py
+++ b/python/fnllm/tests/unit/caching/test_blob.py
@@ -166,3 +166,16 @@ def test_container_name_validation():
     assert validate_blob_container_name("valid-name")
     assert validate_blob_container_name("validname123")
     assert validate_blob_container_name("123validname")
+
+
+async def test_handles_common_errors(blob_cache: BlobCache):
+    # Json Errors
+    blob_cache.blob_client("json_error").upload_blob("""{ "data""")
+    json_value = await blob_cache.get("json_error")
+    assert json_value is None
+
+    # Unicode Errors
+    non_unicode_data = bytes([0x80, 0x81, 0x82])
+    blob_cache.blob_client("unicode_error").upload_blob(non_unicode_data)
+    unicode_value = await blob_cache.get("unicode_error")
+    assert unicode_value is None

--- a/python/fnllm/tests/unit/caching/test_blob.py
+++ b/python/fnllm/tests/unit/caching/test_blob.py
@@ -171,11 +171,11 @@ def test_container_name_validation():
 async def test_handles_common_errors(blob_cache: BlobCache):
     # Json Errors
     blob_cache.blob_client("json_error").upload_blob("""{ "data""")
-    json_value = await blob_cache.get("json_error")
-    assert json_value is None
+    result = await blob_cache.get("json_error")
+    assert result is None
 
     # Unicode Errors
     non_unicode_data = bytes([0x80, 0x81, 0x82])
     blob_cache.blob_client("unicode_error").upload_blob(non_unicode_data)
-    unicode_value = await blob_cache.get("unicode_error")
-    assert unicode_value is None
+    result = await blob_cache.get("unicode_error")
+    assert result is None


### PR DESCRIPTION
This PR updates the cache implementations so that malformed JSON or other common errors result in null cache entries instead of raising errors. This improves the durability of large tasks that may have lots of cache interaction and potentially poisoned entries.