### PR TITLE
rename `cognitive_services_endpoint` to `audience`

### DIFF
--- a/python/essex-config/tests/integration/graphrag_config/llm_parameters.py
+++ b/python/essex-config/tests/integration/graphrag_config/llm_parameters.py
@@ -59,8 +59,8 @@ class LLMParameters(BaseModel):
     proxy: str | None = Field(
         description="The proxy to use for the LLM service.", default=None
     )
-    cognitive_services_endpoint: str | None = Field(
-        description="The endpoint to reach cognitives services.", default=None
+    audience: str | None = Field(
+        description="The authentication audience.", default=None
     )
     deployment_name: str | None = Field(
         description="The deployment name to use for the LLM service.", default=None

--- a/python/fnllm/fnllm/openai/config.py
+++ b/python/fnllm/fnllm/openai/config.py
@@ -78,9 +78,9 @@ class AzureOpenAIConfig(
 
     api_version: str | None = Field(description="The OpenAI API version.")
 
-    cognitive_services_endpoint: str = Field(
+    audience: str = Field(
         default="https://cognitiveservices.azure.com/.default",
-        description="The Azure Cognitive Services endpoint.",
+        description="The Azure OpenAI Audience.",
     )
 
 

--- a/python/fnllm/fnllm/openai/factories/create_azure_openai_client.py
+++ b/python/fnllm/fnllm/openai/factories/create_azure_openai_client.py
@@ -36,4 +36,4 @@ def _get_azure_ad_token_provider(
         return None
 
     credential = credential or DefaultAzureCredential()
-    return get_bearer_token_provider(credential, config.cognitive_services_endpoint)
+    return get_bearer_token_provider(credential, config.audience)


### PR DESCRIPTION
This corrects the terminology used in our configuration to be more accurate.