### PR TITLE
Inject the json strategy enum into the OpenAI Chat LLM

### DIFF
--- a/python/fnllm/fnllm/openai/factories/chat.py
+++ b/python/fnllm/fnllm/openai/factories/chat.py
@@ -88,6 +88,7 @@ def _create_openai_text_chat_llm(
         model_parameters=config.chat_parameters,
         cache=cache_interactor,
         events=events,
+        json_strategy=config.json_strategy,
         json_receiver=create_json_handler(
             config.json_strategy, config.max_json_retries
         ),

--- a/python/fnllm/fnllm/openai/llm/openai_text_chat_llm.py
+++ b/python/fnllm/fnllm/openai/llm/openai_text_chat_llm.py
@@ -82,7 +82,7 @@ class OpenAITextChatLLMImpl(
             OpenAIChatParameters,
         ]
         | None,
-        json_strategy: JsonStrategy = JsonStrategy.VALID,
+        json_strategy: JsonStrategy,
     ):
         """Create a new OpenAIChatLLM."""
         super().__init__(
@@ -202,9 +202,8 @@ class OpenAITextChatLLMImpl(
     ]:
         prompt, kwargs = super()._rewrite_input(prompt, kwargs)
         if self.is_json_mode(kwargs) and self._json_strategy == JsonStrategy.VALID:
-            kwargs["model_parameters"] = self._enable_oai_json_mode(
-                kwargs.get("model_parameters", {})
-            )
+            model_paramaters = kwargs.get("model_parameters", {})
+            kwargs["model_parameters"] = self._enable_oai_json_mode(model_paramaters)
         return prompt, kwargs
 
     def _enable_oai_json_mode(

--- a/python/fnllm/tests/unit/openai/factories/test_chat.py
+++ b/python/fnllm/tests/unit/openai/factories/test_chat.py
@@ -10,6 +10,7 @@ from fnllm.base.services.rate_limiter import RateLimiter
 from fnllm.base.services.retryer import Retryer
 from fnllm.base.services.variable_injector import VariableInjector
 from fnllm.caching.base import Cache
+from fnllm.enums import JsonStrategy
 from fnllm.events.base import LLMEvents
 from fnllm.openai.config import AzureOpenAIConfig
 from fnllm.openai.factories.chat import create_openai_chat_llm
@@ -84,6 +85,7 @@ def test_create_openai_chat_llm():
             ANY,
             model=config.model,
             model_parameters=config.chat_parameters,
+            json_strategy=JsonStrategy.VALID,
             cache=ANY,
             events=mocked_events,
             usage_extractor=ANY,

--- a/python/fnllm/tests/unit/openai/llm/test_chat_text.py
+++ b/python/fnllm/tests/unit/openai/llm/test_chat_text.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 from fnllm.base.services.cache_interactor import CacheInteractor
+from fnllm.enums import JsonStrategy
 from fnllm.events import LLMEvents
 from fnllm.openai.llm.openai_text_chat_llm import OpenAITextChatLLMImpl
 
@@ -11,6 +12,7 @@ def test_child_with_cache():
         cache=CacheInteractor(events=LLMEvents(), cache=None),
         model="model",
         json_receiver=None,
+        json_strategy=JsonStrategy.LOOSE,
     )
     child = llm.child("test")
     assert llm is not child


### PR DESCRIPTION
This allows us to disable JSON mode in older models.