### PR TITLE
[fnllm] Don't use RateLimiter if no limits are defined.

### DIFF
--- a/python/fnllm/CHANGELOG.md
+++ b/python/fnllm/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+- Don't decorate with RateLimiter if no throttles defined.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/python/fnllm/fnllm/openai/factories/chat.py
+++ b/python/fnllm/fnllm/openai/factories/chat.py
@@ -100,7 +100,7 @@ def _create_openai_streaming_chat_llm(
     *,
     client: OpenAIClient,
     config: OpenAIConfig,
-    limiter: Limiter,
+    limiter: Limiter | None,
     events: LLMEvents,
 ) -> OpenAIStreamingChatLLM:
     """Create an OpenAI streaming chat LLM."""

--- a/python/fnllm/fnllm/openai/factories/chat.py
+++ b/python/fnllm/fnllm/openai/factories/chat.py
@@ -71,7 +71,7 @@ def _create_openai_text_chat_llm(
     *,
     client: OpenAIClient,
     config: OpenAIConfig,
-    limiter: Limiter,
+    limiter: Limiter | None,
     cache: Cache | None,
     events: LLMEvents,
 ) -> OpenAITextChatLLM:

--- a/python/fnllm/fnllm/openai/factories/utils.py
+++ b/python/fnllm/fnllm/openai/factories/utils.py
@@ -47,7 +47,7 @@ def create_limiter(config: OpenAIConfig) -> Limiter | None:
     if config.tokens_per_minute:
         limiters.append(TPMLimiter.from_tpm(config.tokens_per_minute))
 
-    if len(limiters == 0):
+    if len(limiters) == 0:
         return None
     if len(limiters) == 1:
         return limiters[0]

--- a/python/fnllm/fnllm/openai/factories/utils.py
+++ b/python/fnllm/fnllm/openai/factories/utils.py
@@ -30,7 +30,7 @@ def _get_encoding(encoding_name: str) -> tiktoken.Encoding:
     return tiktoken.get_encoding(encoding_name)
 
 
-def create_limiter(config: OpenAIConfig) -> Limiter:
+def create_limiter(config: OpenAIConfig) -> Limiter | None:
     """Create an LLM limiter based on the incoming configuration."""
     limiters = []
 
@@ -47,16 +47,22 @@ def create_limiter(config: OpenAIConfig) -> Limiter:
     if config.tokens_per_minute:
         limiters.append(TPMLimiter.from_tpm(config.tokens_per_minute))
 
+    if len(limiters == 0):
+        return None
+    if len(limiters) == 1:
+        return limiters[0]
     return CompositeLimiter(limiters)
 
 
 def create_rate_limiter(
     *,
-    limiter: Limiter,
+    limiter: Limiter | None,
     config: OpenAIConfig,
     events: LLMEvents,
-) -> RateLimiter[Any, Any, Any, Any]:
+) -> RateLimiter[Any, Any, Any, Any] | None:
     """Wraps the LLM to be rate limited."""
+    if limiter is None:
+        return None
     encoding = _get_encoding(config.encoding)
     token_estimator = OpenAITokenEstimator(encoding=encoding)
     return RateLimiter(

--- a/python/fnllm/tests/unit/openai/factories/test_chat.py
+++ b/python/fnllm/tests/unit/openai/factories/test_chat.py
@@ -50,6 +50,7 @@ def test_create_openai_chat_llm():
         deployment="deployment",
         model="my_models",
         chat_parameters={"temperature": 0.5},
+        tokens_per_minute=1000,
     )
     mocked_cache = create_autospec(Cache, instance=True)
     mocked_events = create_autospec(LLMEvents, instance=True)
@@ -117,6 +118,7 @@ def test_invalid_encoding_should_raise():
         encoding="invalid",
         max_retries=2,
         max_retry_wait=15,
+        max_concurrency=2,
     )
 
     with pytest.raises(ValueError):  # noqa: PT011

--- a/python/fnllm/tests/unit/openai/factories/test_embeddings.py
+++ b/python/fnllm/tests/unit/openai/factories/test_embeddings.py
@@ -43,6 +43,7 @@ def test_create_openai_embeddings_llm():
         deployment="deployment",
         model="my_models",
         embeddings_parameters={"user": "some_user"},
+        tokens_per_minute=1000,
     )
     mocked_cache = create_autospec(Cache, instance=True)
     mocked_events = create_autospec(LLMEvents, instance=True)

--- a/python/fnllm/tests/unit/openai/factories/test_utils.py
+++ b/python/fnllm/tests/unit/openai/factories/test_utils.py
@@ -88,7 +88,7 @@ def test_create_retrying_llm():
     assert llm._max_retry_wait == config.max_retry_wait
 
 
-def _assert_concurrency_tpm_rpm(limiter: Limiter, config: OpenAIConfig) -> None:
+def _assert_concurrency_tpm_rpm(limiter: Limiter | None, config: OpenAIConfig) -> None:
     assert isinstance(limiter, CompositeLimiter)
 
     # ConcurrencyLimiter

--- a/python/fnllm/tests/unit/openai/llm/test_chat.py
+++ b/python/fnllm/tests/unit/openai/llm/test_chat.py
@@ -239,6 +239,7 @@ async def test_chat_on_post_limit_event(
         api_version="api_version",
         endpoint="endpoint",
         model="my_model",
+        tokens_per_minute=100,
     )
     mocked_events = Mock(LLMEvents)
 


### PR DESCRIPTION
This PR allows a bypass from using the RateLimiter decorator if no limits are applied.