### PR TITLE
use module level logger

### DIFF
--- a/python/fnllm/fnllm/events/logger.py
+++ b/python/fnllm/fnllm/events/logger.py
@@ -5,23 +5,23 @@
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import TYPE_CHECKING, Any
 
 from fnllm.events.base import LLMEvents
 
 if TYPE_CHECKING:
-    from logging import Logger
-
     from fnllm.limiting.base import Manifest
     from fnllm.types.metrics import LLMMetrics, LLMUsageMetrics
+
+LOGGER = getLogger(__name__)
 
 
 class LLMEventsLogger(LLMEvents):
     """Implementation of the LLM events that just logs the events."""
 
-    def __init__(self, logger: Logger) -> None:
+    def __init__(self) -> None:
         """Create a new LLMEventsLogger."""
-        self._logger = logger
 
     async def on_error(
         self,
@@ -30,7 +30,7 @@ class LLMEventsLogger(LLMEvents):
         arguments: dict[str, Any] | None = None,
     ) -> None:
         """An unhandled error that happens during the LLM call (called by the LLM base)."""
-        self._logger.error(
+        LOGGER.error(
             "unexpected error occurred for arguments '%s':\n\n%s\n\n%s",
             arguments,
             error,
@@ -39,7 +39,7 @@ class LLMEventsLogger(LLMEvents):
 
     async def on_usage(self, usage: LLMUsageMetrics) -> None:
         """Called when there is any LLM usage."""
-        self._logger.debug(
+        LOGGER.debug(
             "LLM usage with %d total tokens (input=%d, output=%d)",
             usage.total_tokens,
             usage.input_tokens,
@@ -48,7 +48,7 @@ class LLMEventsLogger(LLMEvents):
 
     async def on_limit_acquired(self, manifest: Manifest) -> None:
         """Called when limit is acquired for a request (does not include post limiting)."""
-        self._logger.debug(
+        LOGGER.debug(
             "limit acquired for request, request_tokens=%d, post_request_tokens=%d",
             manifest.request_tokens,
             manifest.post_request_tokens,
@@ -56,7 +56,7 @@ class LLMEventsLogger(LLMEvents):
 
     async def on_limit_released(self, manifest: Manifest) -> None:
         """Called when limit is released for a request (does not include post limiting)."""
-        self._logger.debug(
+        LOGGER.debug(
             "limit released for request, request_tokens=%d, post_request_tokens=%d",
             manifest.request_tokens,
             manifest.post_request_tokens,
@@ -64,7 +64,7 @@ class LLMEventsLogger(LLMEvents):
 
     async def on_post_limit(self, manifest: Manifest) -> None:
         """Called when post request limiting is triggered (called by the rate limiting LLM)."""
-        self._logger.debug(
+        LOGGER.debug(
             "post request limiting triggered, acquired extra %d tokens",
             manifest.post_request_tokens,
         )
@@ -74,7 +74,7 @@ class LLMEventsLogger(LLMEvents):
         metrics: LLMMetrics,
     ) -> None:
         """Called when a request goes through (called by the retrying LLM)."""
-        self._logger.debug(
+        LOGGER.debug(
             "request succeed with %d retries in %.2fs and used %d tokens",
             metrics.retry.num_retries,
             metrics.retry.total_time,
@@ -83,7 +83,7 @@ class LLMEventsLogger(LLMEvents):
 
     async def on_cache_hit(self, cache_key: str, name: str | None) -> None:
         """Called when there is a cache hit."""
-        self._logger.debug(
+        LOGGER.debug(
             "cache hit for key=%s and name=%s",
             cache_key,
             name,
@@ -91,7 +91,7 @@ class LLMEventsLogger(LLMEvents):
 
     async def on_cache_miss(self, cache_key: str, name: str | None) -> None:
         """Called when there is a cache miss."""
-        self._logger.debug(
+        LOGGER.debug(
             "cache miss for key=%s and name=%s",
             cache_key,
             name,
@@ -99,13 +99,13 @@ class LLMEventsLogger(LLMEvents):
 
     async def on_try(self, attempt_number: int) -> None:
         """Called every time a new try to call the LLM happens."""
-        self._logger.debug("calling llm, attempt #%d", attempt_number)
+        LOGGER.debug("calling llm, attempt #%d", attempt_number)
 
     async def on_retryable_error(
         self, error: BaseException, attempt_number: int
     ) -> None:
         """Called when retryable errors happen."""
-        self._logger.warning(
+        LOGGER.warning(
             "retryable error happened on attempt #%d: %s", attempt_number, str(error)
         )
 
@@ -113,12 +113,10 @@ class LLMEventsLogger(LLMEvents):
         self, error: BaseException, attempt_number: int
     ) -> None:
         """Called when retryable errors happen."""
-        self._logger.warning(
+        LOGGER.warning(
             "retryable error happened on attempt #%d: %s", attempt_number, str(error)
         )
 
     async def on_recover_from_error(self, attempt_number: int) -> None:
         """Called when the LLM recovers from an error."""
-        self._logger.warning(
-            "recovered from retryable error on attempt #%d", attempt_number
-        )
+        LOGGER.warning("recovered from retryable error on attempt #%d", attempt_number)

--- a/python/fnllm/tests/unit/llm/events/test_logger.py
+++ b/python/fnllm/tests/unit/llm/events/test_logger.py
@@ -2,55 +2,61 @@
 
 """Tests for llm.events.logger."""
 
-from logging import Logger
-from unittest.mock import Mock
+from logging import DEBUG, ERROR, WARNING
 
+import pytest
 from fnllm.events.logger import LLMEventsLogger
 from fnllm.limiting.base import Manifest
 from fnllm.types.metrics import LLMMetrics, LLMUsageMetrics
 
 
-async def test_logger_is_called():
-    logger = Mock(spec=Logger)
-    events = LLMEventsLogger(logger)
+def check_records_and_reset(
+    caplog: pytest.LogCaptureFixture, level: int, prefix: str
+) -> None:
+    assert isinstance(caplog.record_tuples, list)
+    assert len(caplog.records) == 1
+    assert (
+        caplog.record_tuples[0][1] == level
+    ), f"expected {level} but got {caplog.record_tuples[0][1]}"
+    assert caplog.record_tuples[0][0] == "fnllm.events.logger", "unexpected logger name"
+    assert caplog.record_tuples[0][2].startswith(
+        prefix
+    ), f"unexpected message: {caplog.record_tuples[0][2]}"
+    caplog.clear()
 
-    # asserting all events call logger
-    logger.reset_mock()
+
+async def test_logger_is_called(caplog: pytest.LogCaptureFixture):
+    events = LLMEventsLogger()
+    caplog.set_level(DEBUG)
+
+    caplog.clear()
+
     await events.on_error(None, None, {})
-    logger.error.assert_called_once()
+    check_records_and_reset(caplog, ERROR, "unexpected error occurred for arguments")
 
-    logger.reset_mock()
     await events.on_usage(LLMUsageMetrics())
-    logger.debug.assert_called_once()
+    check_records_and_reset(caplog, DEBUG, "LLM usage")
 
-    logger.reset_mock()
     await events.on_limit_acquired(Manifest())
-    logger.debug.assert_called_once()
+    check_records_and_reset(caplog, DEBUG, "limit acquired for request")
 
-    logger.reset_mock()
     await events.on_limit_released(Manifest())
-    logger.debug.assert_called_once()
+    check_records_and_reset(caplog, DEBUG, "limit released for request")
 
-    logger.reset_mock()
     await events.on_post_limit(Manifest())
-    logger.debug.assert_called_once()
+    check_records_and_reset(caplog, DEBUG, "post request limiting triggered")
 
-    logger.reset_mock()
     await events.on_success(LLMMetrics())
-    logger.debug.assert_called_once()
+    check_records_and_reset(caplog, DEBUG, "request succeed with")
 
-    logger.reset_mock()
     await events.on_cache_hit("", "")
-    logger.debug.assert_called_once()
+    check_records_and_reset(caplog, DEBUG, "cache hit for key")
 
-    logger.reset_mock()
     await events.on_cache_miss("", "")
-    logger.debug.assert_called_once()
+    check_records_and_reset(caplog, DEBUG, "cache miss for key")
 
-    logger.reset_mock()
     await events.on_try(1)
-    logger.debug.assert_called_once()
+    check_records_and_reset(caplog, DEBUG, "calling llm, attempt")
 
-    logger.reset_mock()
-    await events.on_retryable_error(Mock(), 1)
-    logger.warning.assert_called_once()
+    await events.on_retryable_error(BaseException(), 1)
+    check_records_and_reset(caplog, WARNING, "retryable error happened on attempt")


### PR DESCRIPTION
Previously, logging was done via a single created logger rather than module level loggers.

This 

This has two downsides:
1. reduces clarity towards where an event gets logged, as it the logs will show the same logger name.  
2. reduces the ability to filter logs based on the module that created the event.

The recommendation from the python project is to use module level loggers, rather than project level.
 
quote from https://docs.python.org/3/howto/logging.html#advanced-logging-tutorial: 
> A good convention to use when naming loggers is to use a module-level logger, in each module which uses logging, named as follows:
>  
> ```python
> logger = logging.getLogger(__name__)
> ```
> This means that logger names track the package/module hierarchy, and it’s intuitively obvious where events are logged just from the logger name.

Additionally, this moves from using `mock` to verify logging works as expected to using the log capture fixture from pytest.