### PR TITLE
Replace 'coverage' with 'pytest-cov'

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,9 +41,17 @@
     "*.js": "${capture}.js.map, ${capture}.min.js, ${capture}.d.ts",
     "*.jsx": "${capture}.js",
     "package.json": ".npmignore, turbo.json, biome.json, tsconfig.json, tsconfig.*.json, jest.config.js, rome.json, .yarnrc.yml, yarn.lock, .pnp.cjs, .pnp.loader.mjs",
-    "pyproject.toml": "uv.lock, ruff.toml, mkdocs.yml",
+    "pyproject.toml": "uv.lock, poetry.lock, ruff.toml, .python-version, mkdocs.yml, nuget.config, .vsts-ci.yml",
+		"cspell.json": "custom-words.txt",
+		"README.md": "ARCHITECTURE.md, DEVELOPING.md, SECURITY.md, SUPPORT.md, CODE_OF_CONDUCT.md, CHANGELOG.md, LICENSE",
+		"graphragcode.sample.yaml": "graphragcode.*.yaml, graphragcode.yaml, graphragcode.log, .env",
+		".coveragerc": "coverage.xml, .coverage",
     ".gitignore": ".gitattributes",
-    "README.md": "SECURITY.md, SUPPORT.md, CODE_OF_CONDUCT.md, CHANGELOG.md, LICENSE"
   },
-  "ruff.configuration": "./ruff.toml"
+  "ruff.configuration": "./ruff.toml",
+  "python.testing.pytestArgs": [
+    "python"
+  ],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
 }

--- a/python/essex-config/.coveragerc
+++ b/python/essex-config/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+omit = tests/*
+
+[report]
+exclude_lines = 
+    pragma: no cover
+    if TYPE_CHECKING:

--- a/python/essex-config/pyproject.toml
+++ b/python/essex-config/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
 
 [tool.uv]
 dev-dependencies = [
-    "coverage>=7.5.4",
+    "pytest-cov>=6.0.0",
+    "pytest-asyncio>=0.24.0",
     "pytest>=8.2.2",
     "ruff>=0.6.8",
     "poethepoet>=0.26.1",
@@ -45,20 +46,20 @@ fix = "ruff  --preview check --fix ."
 fix_unsafe = "ruff check --preview --fix --unsafe-fixes ."
 format = ['_sort_imports', '_format_code']
 test = "pytest tests"
-
-_test_with_coverage = 'coverage run --source=essex_config -m pytest tests/unit'
-_coverage_report = 'coverage report --fail-under=100 --show-missing --omit="essex_config/doc_gen/__main__.py"'
-_generate_coverage_xml = 'coverage xml --omit="essex_config/doc_gen/__main__.py"'
-_generate_coverage_html = 'coverage html --omit="essex_config/doc_gen/__main__.py"'
-test_coverage = [
-    '_test_with_coverage',  
-    '_generate_coverage_xml',
-    '_generate_coverage_html',
-    '_coverage_report'
-]
+test_coverage = "pytest tests --cov-fail-under=96"
 test_only = "pytest -v -k"
 
 # https://github.com/microsoft/pyright/blob/9f81564a4685ff5c55edd3959f9b39030f590b2f/docs/configuration.md#sample-pyprojecttoml-file
 [tool.pyright]
 include = ["essex_config", "tests"]
 exclude = ["**/__pycache__"]
+
+
+[tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope="session"
+addopts="--cov-config=.coveragerc --cov=essex_config --cov-report=html --cov-report=xml --cov-report=term-missing --cov-branch"

--- a/python/fnllm/.coveragerc
+++ b/python/fnllm/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+omit = tests/*
+
+[report]
+exclude_lines = 
+    pragma: no cover
+    if TYPE_CHECKING:

--- a/python/fnllm/pyproject.toml
+++ b/python/fnllm/pyproject.toml
@@ -37,9 +37,9 @@ dev-dependencies = [
     "ruff>=0.6.8",
     "pyright>=1.1.379",
     "pytest>=8.2.2",
-    "coverage>=7.5.4",
     "poethepoet>=0.27.0",
-    "pytest-asyncio>=0.23.7",
+    "pytest-cov>=6.0.0",
+    "pytest-asyncio>=0.24.0",
     "ipykernel>=6.29.5",
     "hatchling>=1.25.0",
     # OpenAI Optional
@@ -70,17 +70,7 @@ fix = "ruff check --preview --fix ."
 fix_unsafe = "ruff check --preview --fix --unsafe-fixes ."
 format = ['_sort_imports', '_format_code']
 test = "pytest tests"
-
-_test_with_coverage = 'coverage run --source=fnllm -m pytest tests/unit'
-_coverage_report = 'coverage report --fail-under=90 --show-missing --omit="fnllm/services/decorator.py,fnllm/types/protocol.py,fnllm/openai/types/client.py"'
-_generate_coverage_xml = 'coverage xml --omit="fnllm/services/decorator.py"'
-_generate_coverage_html = 'coverage html --omit="fnllm/services/decorator.py"'
-test_coverage = [
-    '_test_with_coverage',
-    '_generate_coverage_xml',
-    '_generate_coverage_html',
-    '_coverage_report',
-]
+test_coverage = "pytest tests --cov-fail-under=95"
 test_only = "pytest -v -k"
 
 [tool.pytest.ini_options]
@@ -89,3 +79,5 @@ log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope="session"
+addopts="--cov-config=.coveragerc --cov=fnllm --cov-report=html --cov-report=xml --cov-report=term-missing --cov-branch"

--- a/python/fnllm/pyproject.toml
+++ b/python/fnllm/pyproject.toml
@@ -56,6 +56,11 @@ dev-dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+# https://github.com/microsoft/pyright/blob/9f81564a4685ff5c55edd3959f9b39030f590b2f/docs/configuration.md#sample-pyprojecttoml-file
+[tool.pyright]
+include = ["fnllm", "tests"]
+exclude = ["**/__pycache__"]
+
 
 [tool.poe.tasks]
 _sort_imports = "ruff check --select I --fix . --preview"

--- a/python/reactivedataflow/.coveragerc
+++ b/python/reactivedataflow/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+omit = tests/*
+
+[report]
+exclude_lines = 
+    pragma: no cover
+    if TYPE_CHECKING:

--- a/python/reactivedataflow/pyproject.toml
+++ b/python/reactivedataflow/pyproject.toml
@@ -18,7 +18,8 @@ dev-dependencies = [
     "poethepoet>=0.26.1",
     "pytest>=8.2.2",
     "pyright>=1.1.366",
-    "coverage>=7.5.3",
+    "pytest-cov>=6.0.0",
+    "pytest-asyncio>=0.24.0",
     "numpy<2",
     "pytest-asyncio>=0.23.7"
 ]
@@ -40,17 +41,7 @@ fix = "ruff  --preview check --fix ."
 fix_unsafe = "ruff check --preview --fix --unsafe-fixes ."
 format = ['_sort_imports', '_format_code']
 test = "pytest tests"
-
-_test_with_coverage = 'coverage run --source=reactivedataflow -m pytest tests/unit'
-_coverage_report = 'coverage report --fail-under=100 --show-missing --omit="reactivedataflow/nodes/node.py,reactivedataflow/types.py,reactivedataflow/config_provider.py,reactivedataflow/callbacks.py"'
-_generate_coverage_xml = 'coverage xml --omit="reactivedataflow/nodes/node.py,reactivedataflow/types.py,reactivedataflow/config_provider.py,reactivedataflow/callbacks.py"'
-_generate_coverage_html = 'coverage html --omit="reactivedataflow/nodes/node.py,reactivedataflow/types.py,reactivedataflow/config_provider.py,reactivedataflow/callbacks.py"'
-test_coverage = [
-    '_test_with_coverage',  
-    '_generate_coverage_xml',
-    '_generate_coverage_html',
-    '_coverage_report'
-]
+test_coverage = "pytest tests --cov-fail-under=98"
 test_only = "pytest -v -k"
 
 [tool.pytest.ini_options]
@@ -59,3 +50,5 @@ log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope="session"
+addopts="--cov-config=.coveragerc --cov=reactivedataflow --cov-report=html --cov-report=xml --cov-report=term-missing --cov-branch"

--- a/python/reactivedataflow/pyproject.toml
+++ b/python/reactivedataflow/pyproject.toml
@@ -28,6 +28,11 @@ dev-dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+# https://github.com/microsoft/pyright/blob/9f81564a4685ff5c55edd3959f9b39030f590b2f/docs/configuration.md#sample-pyprojecttoml-file
+[tool.pyright]
+include = ["reactivedataflow", "tests"]
+exclude = ["**/__pycache__"]
+
 [tool.poe.tasks]
 _sort_imports = "ruff check --select I --fix . --preview"
 _ruff_check = 'ruff check . --preview'

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 
 [manifest]
@@ -348,6 +349,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/b2/f655700e1024dec98b10ebaafd0cedbc25e40e4abe62a3c8e2ceef4f8f0a/coverage-7.6.12-py3-none-any.whl", hash = "sha256:eb8668cfbc279a536c633137deeb9435d2962caec279c3f8cf8b91fff6ff8953", size = 200552 },
 ]
 
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
 [[package]]
 name = "cryptography"
 version = "44.0.1"
@@ -450,11 +456,12 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "coverage" },
     { name = "hatchling" },
     { name = "poethepoet" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
@@ -473,11 +480,12 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "coverage", specifier = ">=7.5.4" },
     { name = "hatchling", specifier = ">=1.25.0" },
     { name = "poethepoet", specifier = ">=0.26.1" },
     { name = "pyright", specifier = ">=1.1.365" },
     { name = "pytest", specifier = ">=8.2.2" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.6.8" },
 ]
 
@@ -549,7 +557,6 @@ openai = [
 dev = [
     { name = "azure-identity" },
     { name = "azure-storage-blob" },
-    { name = "coverage" },
     { name = "hatchling" },
     { name = "ipykernel" },
     { name = "numpy" },
@@ -558,6 +565,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "ruff" },
     { name = "tiktoken" },
 ]
@@ -575,12 +583,12 @@ requires-dist = [
     { name = "tenacity", specifier = ">=8.5.0" },
     { name = "tiktoken", marker = "extra == 'openai'", specifier = ">=0.7.0" },
 ]
+provides-extras = ["openai", "azure", "numpy"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "azure-identity", specifier = ">=1.17.1" },
     { name = "azure-storage-blob", specifier = ">=12.20.0" },
-    { name = "coverage", specifier = ">=7.5.4" },
     { name = "hatchling", specifier = ">=1.25.0" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "numpy", specifier = ">=1.26.4" },
@@ -588,7 +596,8 @@ dev = [
     { name = "poethepoet", specifier = ">=0.27.0" },
     { name = "pyright", specifier = ">=1.1.379" },
     { name = "pytest", specifier = ">=8.2.2" },
-    { name = "pytest-asyncio", specifier = ">=0.23.7" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.6.8" },
     { name = "tiktoken", specifier = ">=0.8.0" },
 ]
@@ -1493,6 +1502,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949 },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1685,12 +1707,12 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "coverage" },
     { name = "numpy" },
     { name = "poethepoet" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
@@ -1703,12 +1725,13 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "coverage", specifier = ">=7.5.3" },
     { name = "numpy", specifier = "<2" },
     { name = "poethepoet", specifier = ">=0.26.1" },
     { name = "pyright", specifier = ">=1.1.366" },
     { name = "pytest", specifier = ">=8.2.2" },
     { name = "pytest-asyncio", specifier = ">=0.23.7" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.6.8" },
 ]
 


### PR DESCRIPTION
Using `pytest-cov` simplifies our test orchestration a great deal, and it will allow us to more deeply integrate with VSCode's integrated testing/coverage features (in time).  This configuration also improves our coverage metrics by ignoring `if TYPE_CHECKING:` blocks, which cannot really be covered. 
