### PR TITLE
Proposal: Use Dynamic Versioning for Managed Release Tags & Prerelease Flow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,7 +1,9 @@
 name: Python-Publish-CI
 on:
+  release:
+    types: [created]
   push:
-      branches: [main]
+    branches: [main]
 
 env:
   UV_VERSION: "0.4.17"

--- a/python/fnllm/README.md
+++ b/python/fnllm/README.md
@@ -12,6 +12,10 @@ pip install fnllm
 
 `fnllm` is an LLM wrapper that provides function-based protocols for accessing LLM functionality (e.g. `fnllm.types.ChatLLM`, `fnllm.types.EmbeddingsLLM`). It's designed to be provider-agnostic, but it currently uses OpenAI as the default provider. 
 
+## Maintenance Expectations
+
+`fnllm` is a research grade library used by Microsoft Research. It changes rapidly, and although we try to adhere to Semantic Versioning, there may be occasional unintended breaking changes. If you use `fnllm`, we recommend pinning your client version and validating new versions.
+
 ## Chain of Responsibility
 A key feature of `fnllm` is that it hides several key concerns behind a _chain of responsibility_ abstraction in order to ensure fast and durable data-processing jobs. These concerns include _retrying_, _throttling_, _caching_ and _json recovery_. 
 

--- a/python/fnllm/README.md
+++ b/python/fnllm/README.md
@@ -12,7 +12,7 @@ pip install fnllm
 
 `fnllm` is an LLM wrapper that provides function-based protocols for accessing LLM functionality (e.g. `fnllm.types.ChatLLM`, `fnllm.types.EmbeddingsLLM`). It's designed to be provider-agnostic, but it currently uses OpenAI as the default provider. 
 
-> `fnllm` is a research grade library used by Microsoft Research. It changes rapidly, and although we try to adhere to Semantic Versioning, there may be occasional unintended breaking changes. If you use `fnllm`, we recommend pinning your client version and validating new versions.
+> ⚠️ `fnllm` is a research grade library used by Microsoft Research. It changes rapidly, and although we try to adhere to Semantic Versioning, there may be occasional unintended breaking changes. If you use `fnllm`, we recommend pinning your client version and validating new versions.
 
 ## Chain of Responsibility
 A key feature of `fnllm` is that it hides several key concerns behind a _chain of responsibility_ abstraction in order to ensure fast and durable data-processing jobs. These concerns include _retrying_, _throttling_, _caching_ and _json recovery_. 

--- a/python/fnllm/README.md
+++ b/python/fnllm/README.md
@@ -12,9 +12,7 @@ pip install fnllm
 
 `fnllm` is an LLM wrapper that provides function-based protocols for accessing LLM functionality (e.g. `fnllm.types.ChatLLM`, `fnllm.types.EmbeddingsLLM`). It's designed to be provider-agnostic, but it currently uses OpenAI as the default provider. 
 
-## Maintenance Expectations
-
-`fnllm` is a research grade library used by Microsoft Research. It changes rapidly, and although we try to adhere to Semantic Versioning, there may be occasional unintended breaking changes. If you use `fnllm`, we recommend pinning your client version and validating new versions.
+> `fnllm` is a research grade library used by Microsoft Research. It changes rapidly, and although we try to adhere to Semantic Versioning, there may be occasional unintended breaking changes. If you use `fnllm`, we recommend pinning your client version and validating new versions.
 
 ## Chain of Responsibility
 A key feature of `fnllm` is that it hides several key concerns behind a _chain of responsibility_ abstraction in order to ensure fast and durable data-processing jobs. These concerns include _retrying_, _throttling_, _caching_ and _json recovery_. 

--- a/python/fnllm/pyproject.toml
+++ b/python/fnllm/pyproject.toml
@@ -61,6 +61,11 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "uv-dynamic-versioning"
 
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+pattern-prefix = "fnllm_"
+
 # https://github.com/microsoft/pyright/blob/9f81564a4685ff5c55edd3959f9b39030f590b2f/docs/configuration.md#sample-pyprojecttoml-file
 [tool.pyright]
 include = ["fnllm", "fnllm_tests"]

--- a/python/fnllm/pyproject.toml
+++ b/python/fnllm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fnllm"
-version = "0.2.8"
+dynamic = ["version"]
 description = "A function-based LLM protocol and wrapper."
 authors = [
     {name="Chris Trevino", email="chtrevin@microsoft.com"},
@@ -51,11 +51,15 @@ dev-dependencies = [
     # Numpy Optional
     "numpy>=1.26.4",
     "polyfactory>=2.19.0",
+    "uv-dynamic-versioning>=0.6.0",
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
 
 # https://github.com/microsoft/pyright/blob/9f81564a4685ff5c55edd3959f9b39030f590b2f/docs/configuration.md#sample-pyprojecttoml-file
 [tool.pyright]

--- a/python/fnllm/pyproject.toml
+++ b/python/fnllm/pyproject.toml
@@ -64,7 +64,8 @@ source = "uv-dynamic-versioning"
 [tool.uv-dynamic-versioning]
 vcs = "git"
 style = "pep440"
-pattern-prefix = "fnllm_"
+# This allows us to match project-specific release tags (e.g.. 'fnllm-v0.3.0')
+pattern-prefix = "fnllm-"
 
 # https://github.com/microsoft/pyright/blob/9f81564a4685ff5c55edd3959f9b39030f590b2f/docs/configuration.md#sample-pyprojecttoml-file
 [tool.pyright]

--- a/uv.lock
+++ b/uv.lock
@@ -460,6 +460,18 @@ wheels = [
 ]
 
 [[package]]
+name = "dunamai"
+version = "1.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/14/4932a8aee6df2f266c748f88d27a455719d04ca5cf723d5630b7fb215d61/dunamai-1.23.1.tar.gz", hash = "sha256:0b5712fc63bfb235263d912bfc5eb84590ba2201bb737268d25a5dbad7085489", size = 45066 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/e6/6621a99488e8457585cbc4565b18c1a1591e1eae67adcd530ffa7c0bd30e/dunamai-1.23.1-py3-none-any.whl", hash = "sha256:2611b0b9105a5797149ef82f4968a01dd912bdac857d49fc06856a4cfa58cf78", size = 26500 },
+]
+
+[[package]]
 name = "essex-config"
 version = "0.0.6"
 source = { editable = "python/essex-config" }
@@ -563,7 +575,7 @@ wheels = [
 
 [[package]]
 name = "fnllm"
-version = "0.2.8"
+version = "0.2.8.dev1"
 source = { editable = "python/fnllm" }
 dependencies = [
     { name = "aiolimiter" },
@@ -602,6 +614,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "tiktoken" },
+    { name = "uv-dynamic-versioning" },
 ]
 
 [package.metadata]
@@ -635,6 +648,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.6.8" },
     { name = "tiktoken", specifier = ">=0.8.0" },
+    { name = "uv-dynamic-versioning", specifier = ">=0.6.0" },
 ]
 
 [[package]]
@@ -1921,6 +1935,18 @@ wheels = [
 ]
 
 [[package]]
+name = "returns"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/2c/90479667b4e46759c11d7c0e04f2ffa47e3cdabb1984d06a004e6c523ef2/returns-0.25.0.tar.gz", hash = "sha256:1bf547311c0ade25435ce3bbe81642c325ea6b86beaf5d624cd410f0dee3ff50", size = 105128 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/95/3fd02e08fa0d9ec9127b8f1379eda36b0b070096eee1a7038042508ae381/returns-0.25.0-py3-none-any.whl", hash = "sha256:bdc6ec52d28e74d6965f6de5a3af5e39427e67266014b605865fe2e194a75ed0", size = 160145 },
+]
+
+[[package]]
 name = "rich"
 version = "13.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2094,6 +2120,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tomlkit"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/09/a439bec5888f00a54b8b9f05fa94d7f901d6735ef4e55dcec9bc37b5d8fa/tomlkit-0.13.2.tar.gz", hash = "sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79", size = 192885 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl", hash = "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde", size = 37955 },
+]
+
+[[package]]
 name = "tornado"
 version = "6.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2179,6 +2214,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369 },
+]
+
+[[package]]
+name = "uv-dynamic-versioning"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dunamai" },
+    { name = "hatchling" },
+    { name = "pydantic" },
+    { name = "returns" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a3/2a639c01dbcd3b27726366a1ed7508bc797ceee7c5ba9aec41f3ff5b014f/uv_dynamic_versioning-0.6.0.tar.gz", hash = "sha256:43a2a18cd60fd7c24abe18a3a0573a9501de92f6267c54a6fa71851c01c3aa87", size = 30897 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/f9/015ec98f688603f18630d2c78101b9251273abf76ae36cccf041eb3fd5ec/uv_dynamic_versioning-0.6.0-py3-none-any.whl", hash = "sha256:2671783473e50377ae800fb9253b5651af40d30300e1485ce1db23718b1e3196", size = 8385 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR uses a pattern similar to GraphRAG, where we utilize a dynamic versioning plugin that allows us to control releases via release tags. 

## Release Flow
Similar to other projects, we augment the Python release Github Action so that releases are triggered on main by default, and when releases are created in GithHub.  By default, prereleases will be published to PyPi for every commit that lands on main. And final releases will be cut when a release is created. This will allow us to validate prereleases prior to committing to a public release.

## Monorepo Tag Management
Because this is in a monorepo, the expected tag format has a project prefix, e.g.: `fnllm-v1.2.3`

## Remaining Work
The next step in this proposal would be automated validation (smoke testing) of prereleases in `graphrag`, or other verified clients as our release acceptance flow.