### PR TITLE
[CI] Use checkout v4; checkout tags in publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-tags: true
+          fetch-depth: 0
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+  # TODO: remove after test
+  pull_request:
+    # Nothing
+
 env:
   UV_VERSION: "0.4.17"
   PYTHON_VERSION: "3.11"
@@ -26,7 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true
           fetch-depth: 0
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches: [main]
 
-  # TODO: remove after test
-  pull_request:
-    # Nothing
-
 env:
   UV_VERSION: "0.4.17"
   PYTHON_VERSION: "3.11"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+  # TODO: remove after test
+  pull_request:
+    # Nothing
+
 env:
   UV_VERSION: "0.4.17"
   PYTHON_VERSION: "3.11"
@@ -12,7 +16,6 @@ env:
 jobs:
   publish:
     name: Upload python projects to PyPI
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,7 +28,9 @@ jobs:
         id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2


### PR DESCRIPTION
* Because we are using dynamic-versioning, we need the full git history to infer the final version of a release, hence `fetch-depth: 0`
* Because we are publishing on tags, we remove the github.ref == 'main' check.