### PR TITLE
[fnllm] Replace `sleep_on_rate_limit_recommendation` with `rate_limit_behavior`

### DIFF
--- a/python/fnllm/CHANGELOG.md
+++ b/python/fnllm/CHANGELOG.md
@@ -20,10 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add HTTP header reactive updates to TPM/RPM throttles. By setting tpm or rpm to 'auto', the throttle will be started in dynamic mode.
 - Add events method for limit reconciliation.
+- Add `config.rate_limit_behavior` to control how we react to OpenAI rate limiting errors.
 ### Changed
 - Update OpenAIRetryableErrorHandle to inspect error headers instead of the error message.
 ### Deprecated
 ### Removed
+- Remove `config.sleep_on_rate_limit_recommendation`.
 ### Fixed
 ### Security
 

--- a/python/fnllm/fnllm/openai/__init__.py
+++ b/python/fnllm/fnllm/openai/__init__.py
@@ -3,7 +3,12 @@
 
 """OpenAI LLM implementations."""
 
-from .config import AzureOpenAIConfig, OpenAIConfig, PublicOpenAIConfig
+from .config import (
+    AzureOpenAIConfig,
+    OpenAIConfig,
+    OpenAIRateLimitBehavior,
+    PublicOpenAIConfig,
+)
 from .factories import (
     create_openai_chat_llm,
     create_openai_client,
@@ -25,6 +30,7 @@ __all__ = [
     "OpenAIConfig",
     "OpenAIConfig",
     "OpenAIEmbeddingsLLM",
+    "OpenAIRateLimitBehavior",
     "OpenAIStreamingChatLLM",
     "OpenAITextChatLLM",
     "PublicOpenAIConfig",

--- a/python/fnllm/fnllm/openai/config.py
+++ b/python/fnllm/fnllm/openai/config.py
@@ -3,6 +3,7 @@
 
 """OpenAI Configuration class definition."""
 
+from enum import Enum
 from typing import Annotated, Literal
 
 from pydantic import Field
@@ -10,6 +11,19 @@ from pydantic import Field
 from fnllm.base.config import Config
 from fnllm.openai.types.chat.parameters import OpenAIChatParameters
 from fnllm.openai.types.embeddings.parameters import OpenAIEmbeddingsParameters
+
+
+class OpenAIRateLimitBehavior(str, Enum):
+    """The behavior to use when a RateLimitError is encountered."""
+
+    NONE = "none"
+    """Do nothing when a rate limit is encountered"""
+
+    SLEEP = "sleep"
+    """Block all requests until the ratelimit time has elapsed"""
+
+    SLEEP_LOCAL = "sleep_local"
+    """Block the current request from resolving the ratelimit time has elapsed"""
 
 
 class CommonOpenAIConfig(Config, frozen=True, extra="allow", protected_namespaces=()):
@@ -43,9 +57,9 @@ class CommonOpenAIConfig(Config, frozen=True, extra="allow", protected_namespace
         description="Global embeddings parameters to be used across calls.",
     )
 
-    sleep_on_rate_limit_recommendation: bool = Field(
-        default=False,
-        description="Whether to sleep on rate limit recommendation.",
+    rate_limit_behavior: OpenAIRateLimitBehavior = Field(
+        default=OpenAIRateLimitBehavior.SLEEP,
+        description="The rate-limiting behavior to employ when a RateLimitError is encountered.",
     )
 
 

--- a/python/fnllm/fnllm/openai/config.py
+++ b/python/fnllm/fnllm/openai/config.py
@@ -19,11 +19,11 @@ class OpenAIRateLimitBehavior(str, Enum):
     NONE = "none"
     """Do nothing when a rate limit is encountered"""
 
-    SLEEP = "sleep"
-    """Block all requests until the ratelimit time has elapsed"""
+    LIMIT = "limit"
+    """Use the limiter stack to block requests until the ratelimit time has elapsed."""
 
-    SLEEP_LOCAL = "sleep_local"
-    """Block the current request from resolving the ratelimit time has elapsed"""
+    SLEEP = "sleep"
+    """Perform a task-local sleep until the ratelimit time has elapsed."""
 
 
 class CommonOpenAIConfig(Config, frozen=True, extra="allow", protected_namespaces=()):
@@ -58,7 +58,7 @@ class CommonOpenAIConfig(Config, frozen=True, extra="allow", protected_namespace
     )
 
     rate_limit_behavior: OpenAIRateLimitBehavior = Field(
-        default=OpenAIRateLimitBehavior.SLEEP,
+        default=OpenAIRateLimitBehavior.LIMIT,
         description="The rate-limiting behavior to employ when a RateLimitError is encountered.",
     )
 

--- a/python/fnllm/fnllm/openai/factories/chat.py
+++ b/python/fnllm/fnllm/openai/factories/chat.py
@@ -58,7 +58,7 @@ def create_openai_chat_llm(
     client = client or create_openai_client(config)
     events = events or LLMEvents()
 
-    backoff_limiter = create_backoff_limiter(config)
+    backoff_limiter = create_backoff_limiter()
     limiter = create_limiter(config, backoff_limiter)
 
     text_chat_llm = _create_openai_text_chat_llm(

--- a/python/fnllm/fnllm/openai/factories/embeddings.py
+++ b/python/fnllm/fnllm/openai/factories/embeddings.py
@@ -42,7 +42,7 @@ def create_openai_embeddings_llm(
     operation = "embedding"
     client = client or create_openai_client(config)
     events = events or LLMEvents()
-    backoff_limiter = create_backoff_limiter(config)
+    backoff_limiter = create_backoff_limiter()
     limiter = create_limiter(config, backoff_limiter)
     return OpenAIEmbeddingsLLMImpl(
         client,

--- a/python/fnllm/fnllm/openai/factories/utils.py
+++ b/python/fnllm/fnllm/openai/factories/utils.py
@@ -58,11 +58,9 @@ def _rpm_reconciler(output: LLMOutput[Any, Any, Any]) -> LimitReconciliation:
     )
 
 
-def create_backoff_limiter(
-    config: OpenAIConfig,
-) -> OpenAIBackoffLimiter | None:
+def create_backoff_limiter() -> OpenAIBackoffLimiter:
     """Create an LLM limiter based on the incoming configuration."""
-    return OpenAIBackoffLimiter() if config.sleep_on_rate_limit_recommendation else None
+    return OpenAIBackoffLimiter()
 
 
 def create_limiter(
@@ -147,7 +145,9 @@ def create_retryer(
         return None
     handler = None
     if backoff_limiter is not None:
-        handler = OpenAIRetryableErrorHandler(backoff_limiter)
+        handler = OpenAIRetryableErrorHandler(
+            backoff_limiter, config.rate_limit_behavior
+        )
     return Retryer(
         tag=operation,
         max_retries=config.max_retries,

--- a/python/fnllm/fnllm/openai/services/openai_retryable_error_handler.py
+++ b/python/fnllm/fnllm/openai/services/openai_retryable_error_handler.py
@@ -94,4 +94,3 @@ class OpenAIRetryableErrorHandler:
                 await asyncio.sleep(retry_after)
             case OpenAIRateLimitBehavior.NONE:
                 pass
-        return

--- a/python/fnllm/fnllm/openai/services/openai_retryable_error_handler.py
+++ b/python/fnllm/fnllm/openai/services/openai_retryable_error_handler.py
@@ -88,9 +88,9 @@ class OpenAIRetryableErrorHandler:
     async def _handle_retry_after(self, retry_after: float) -> None:
         """Handle the retry after header."""
         match self._strategy:
-            case OpenAIRateLimitBehavior.SLEEP:
+            case OpenAIRateLimitBehavior.LIMIT:
                 await self._limiter.sleep_for(retry_after)
-            case OpenAIRateLimitBehavior.SLEEP_LOCAL:
+            case OpenAIRateLimitBehavior.SLEEP:
                 await asyncio.sleep(retry_after)
             case OpenAIRateLimitBehavior.NONE:
                 pass

--- a/python/fnllm/fnllm/openai/services/openai_retryable_error_handler.py
+++ b/python/fnllm/fnllm/openai/services/openai_retryable_error_handler.py
@@ -56,7 +56,7 @@ class OpenAIBackoffLimiter(Limiter):
         """Release a pass through the limiter."""
         # No-op in this implementation, but can be extended if needed.
 
-    async def sleep_for(self, time: int) -> None:
+    async def sleep_for(self, time: float) -> None:
         """Sleep for the given amount of time."""
         self._delay_event.clear()  # Block acquire() calls
         try:
@@ -81,11 +81,11 @@ class OpenAIRetryableErrorHandler:
             case APIStatusError():
                 retry_after = error.response.headers.get("retry-after", None)
                 if retry_after is not None:
-                    await self._handle_retry_after(int(retry_after))
+                    await self._handle_retry_after(float(retry_after))
             case _:
                 pass
 
-    async def _handle_retry_after(self, retry_after: int) -> None:
+    async def _handle_retry_after(self, retry_after: float) -> None:
         """Handle the retry after header."""
         match self._strategy:
             case OpenAIRateLimitBehavior.SLEEP:

--- a/python/fnllm/fnllm_tests/unit/openai/services/test_openai_retryable_error_handler.py
+++ b/python/fnllm/fnllm_tests/unit/openai/services/test_openai_retryable_error_handler.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2024 Microsoft Corporation.
+"""Unit tests for the OpenAIRetryableErrorHandler class."""
+
+import asyncio
+from typing import Any, cast
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fnllm.base.services.rate_limiter import Manifest
+from fnllm.openai.config import OpenAIRateLimitBehavior
+from fnllm.openai.services.openai_retryable_error_handler import (
+    OpenAIBackoffLimiter,
+    OpenAIRetryableErrorHandler,
+)
+from openai import APIStatusError
+
+
+# Dummy error to simulate APIStatusError with a retry-after header.
+class DummyResponse:
+    def __init__(self, retry_after: str):
+        self.headers = {"retry-after": retry_after}
+
+
+class DummyAPIStatusError(APIStatusError):
+    def __init__(self, retry_after: str):
+        self.response = cast(Any, DummyResponse(retry_after))
+
+
+async def test_backoff_limiter_acquires_when_unblocked():
+    limiter = OpenAIBackoffLimiter()
+    # Start with an open state: acquire() should complete immediately
+    await limiter.acquire(Manifest())
+    # Start a sleep in the limiter that blocks further acquire() calls.
+    sleep_task = asyncio.create_task(limiter.sleep_for(0.2))
+    # Immediately try to acquire; this task should be blocked.
+    acquire_task = asyncio.create_task(limiter.acquire(Manifest()))
+
+    # Assert that acquire_task remains pending (times out) before sleep completes.
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(acquire_task, timeout=0.05)
+
+    await sleep_task
+
+
+async def test_backoff_limiter_blocks_on_sleep():
+    limiter = OpenAIBackoffLimiter()
+    # Start a sleep in the limiter that blocks further acquire() calls.
+    sleep_task = asyncio.create_task(limiter.sleep_for(0.2))
+    # Immediately try to acquire; this task should be blocked.
+    acquire_task = asyncio.create_task(limiter.acquire(Manifest()))
+
+    # Assert that acquire_task remains pending (times out) before sleep completes.
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(acquire_task, timeout=0.05)
+
+    await sleep_task
+
+
+async def test_backoff_limiter_unblocks_after_sleep():
+    limiter = OpenAIBackoffLimiter()
+    # Start a sleep in the limiter that blocks further acquire() calls.
+    sleep_task = asyncio.create_task(limiter.sleep_for(0.2))
+    # Immediately try to acquire; this task should be blocked.
+    acquire_task = asyncio.create_task(limiter.acquire(Manifest()))
+    await sleep_task
+    await asyncio.wait_for(acquire_task, timeout=0.001)
+
+
+async def test_retryable_error_handler_unknown_error_bypasses_limiter():
+    limiter = Mock()
+    handler = OpenAIRetryableErrorHandler(
+        limiter, strategy=OpenAIRateLimitBehavior.SLEEP
+    )
+    await handler.__call__(ValueError())
+
+
+async def test_retryable_error_handler_none_strategy_skips_sleep():
+    sleep_for = AsyncMock()
+    limiter = Mock()
+    limiter.sleep_for = sleep_for
+    handler = OpenAIRetryableErrorHandler(
+        limiter, strategy=OpenAIRateLimitBehavior.NONE
+    )
+    await handler.__call__(DummyAPIStatusError("1"))
+    sleep_for.assert_not_called()


### PR DESCRIPTION
This PR updates the OpenAIRetryableErrorHandler to support a couple of different sleep stategies. We support:

* OpenAIRateLimitBehavior.LIMIT: This signals a `Limiter` instance to stop issuing permits until the sleep time has elapsed.
* OpenAIRateLImitBehavior.SLEEP: This is the behavior of `sleep_on_rate_limit_recommendation`, which is to sleep the current task, but not other tasks.
* OpenAIRateLimitBehavior.NONE: This skips any sleeping