### PR TITLE
fix: Make sure delta is not None

### DIFF
--- a/python/fnllm/CHANGELOG.md
+++ b/python/fnllm/CHANGELOG.md
@@ -15,12 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ```
+
 ## [Unreleased]
 ### Added
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix issue with OpenAIStreamingChatLLM when `delta` is not present in the response.
 ### Security
 
 ## [0.3.0] - 2025-04-09

--- a/python/fnllm/fnllm/openai/llm/openai_streaming_chat_llm.py
+++ b/python/fnllm/fnllm/openai/llm/openai_streaming_chat_llm.py
@@ -168,7 +168,7 @@ class StreamingChatIterator:
                         self._on_usage(usage)
                     await self._events.on_usage(usage)
 
-                if chunk.choices and len(chunk.choices) > 0:
+                if chunk.choices and len(chunk.choices) > 0 and chunk.choices[0].delta:
                     yield chunk.choices[0].delta.content
         except BaseException as e:
             stack_trace = traceback.format_exc()


### PR DESCRIPTION
In some cases the `chunk.choices[0].delta` is None, causing the following error: AttributeError: 'NoneType' object has no attribute 'content'.

This has been reported as an issue:  [387](https://github.com/microsoft/essex-toolkit/issues/387).

